### PR TITLE
Nome de NPC inexistente

### DIFF
--- a/npc/missoes/quests_airship.txt
+++ b/npc/missoes/quests_airship.txt
@@ -1211,7 +1211,7 @@ OnTimer34000:
 	end;
 OnTimer38000:
 	mapannounce "airplane_01", "Captain: All passengers on deck, please find shelter inside the ship!",bc_map,0x00ff00;
-	hideonnpc "Airship Staff#airplane01";
+	hideonnpc "Assist. do Aeroplano#airplane";
 	end;
 OnTimer48000:
 	monster "airplane_01",245,57,"Gremlin",1632,1,"Airship#airplane02::OnMyMobDead";
@@ -1505,7 +1505,7 @@ OnTimer400000:
 	end;
 OnTimer405000:
 	mapannounce "airplane_01","Monster threat eliminated. The Airship is now returning to normal operation.",bc_map,0x00FF00;
-	hideoffnpc "Airship Staff#airplane01";
+	hideoffnpc "Assist. do Aeroplano#airplane";
 	end;
 OnTimer410000:
 	mapannounce "airplane_01","We will arrive in Izlude shortly.",bc_map,"0x00ff00";


### PR DESCRIPTION
Atualmente o emulador tenta esconder o NPC, porem passa o nome incorreto, fazendo que apareça os seguintes erros no map-server:
- [Erro]: [NPC] - Tentativa de esconder em um NPC inexistente NPC (Nome: 'AirshipStaff#airplane01' | flag: 4).
- [Erro]: [NPC] - Tentativa de mostrar em um NPC inexistente NPC (Nome: 'Airship Staff#airplane01' | flag: 2).
