### PR TITLE
Update EndlessTower.txt

### DIFF
--- a/npc/instancias/EndlessTower.txt
+++ b/npc/instancias/EndlessTower.txt
@@ -1451,7 +1451,7 @@ OnTimer5000:
 2@tower,96,138,0	duplicate(1FGate102tower)	42FGate102tower	WARPNPC,2,2
 2@tower,184,138,0	duplicate(1FGate102tower)	43FGate102tower	WARPNPC,2,2
 2@tower,270,138,0	duplicate(1FGate102tower)	44FGate102tower	WARPNPC,2,2
-2@tower,355,138,0	duplicate(1FGate102tower)	WARPNPCFGate102tower	WARPNPC,2,2
+2@tower,355,138,0	duplicate(1FGate102tower)	45Gate102tower	WARPNPC,2,2
 2@tower,12,51,0	duplicate(1FGate102tower)	46FGate102tower	WARPNPC,2,2
 2@tower,96,51,0	duplicate(1FGate102tower)	47FGate102tower	WARPNPC,2,2
 2@tower,184,51,0	duplicate(1FGate102tower)	48FGate102tower	WARPNPC,2,2


### PR DESCRIPTION
Linha 1454 com parametros errados.

alterado de
2@tower,355,138,0    duplicate(1FGate102tower)    WARPNPCFGate102tower    WARPNPC,2,2

para
2@tower,355,138,0    duplicate(1FGate102tower)    45Gate102tower    WARPNPC,2,2
