### PR TITLE
Cleaning conditional directives that break statements.

### DIFF
--- a/src/map/clif.c
+++ b/src/map/clif.c
@@ -10761,6 +10761,8 @@ void clif_parse_ChangeCart(int fd,struct map_session_data *sd)
 {// TODO: State tracking?
 	int type;
 
+	bool type_sd_test;
+
 	if( pc->checkskill(sd, MC_CHANGECART) < 1 )
 		return;
 
@@ -10773,22 +10775,23 @@ void clif_parse_ChangeCart(int fd,struct map_session_data *sd)
 
 	type = (int)RFIFOW(fd,2);
 #ifdef NEW_CARTS
-	if( (type == 9 && sd->status.base_level > 131) ||
-		(type == 8 && sd->status.base_level > 121) ||
-		(type == 7 && sd->status.base_level > 111) ||
-		(type == 6 && sd->status.base_level > 101) ||
-		(type == 5 && sd->status.base_level >  90) ||
-		(type == 4 && sd->status.base_level >  80) ||
-		(type == 3 && sd->status.base_level >  65) ||
-		(type == 2 && sd->status.base_level >  40) ||
-		(type == 1))
+	type_sd_test = 	(type == 9 && sd->status.base_level > 131) ||
+			(type == 8 && sd->status.base_level > 121) ||
+			(type == 7 && sd->status.base_level > 111) ||
+			(type == 6 && sd->status.base_level > 101) ||
+			(type == 5 && sd->status.base_level >  90) ||
+			(type == 4 && sd->status.base_level >  80) ||
+			(type == 3 && sd->status.base_level >  65) ||
+			(type == 2 && sd->status.base_level >  40) ||
+			(type == 1);
 #else
-	if( (type == 5 && sd->status.base_level > 90) ||
-	    (type == 4 && sd->status.base_level > 80) ||
-	    (type == 3 && sd->status.base_level > 65) ||
-	    (type == 2 && sd->status.base_level > 40) ||
-	    (type == 1))
+	type_sd_test = 	(type == 5 && sd->status.base_level > 90) ||
+	    		(type == 4 && sd->status.base_level > 80) ||
+	    		(type == 3 && sd->status.base_level > 65) ||
+	    		(type == 2 && sd->status.base_level > 40) ||
+	    		(type == 1);
 #endif
+	if (type_sd_test)
 		pc->setcart(sd,type);
 }
 


### PR DESCRIPTION
  A suggestion to compile entire statements and expressions, as suggested by code style guidelines from the Linux Kernel and practitioners.

    https://git.kernel.org/cgit/linux/kernel/git/torvalds/linux.git/tree/Documentation/CodingStyle#n892
    https://www.cqse.eu/en/blog/living-in-the-ifdef-hell/

It might improve code understanding, maintainability and error-proneness.